### PR TITLE
Upgrade junit to version 4.13.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Fix for dependabot alert: Upgrade junit:junit to version 4.13.1 or later.